### PR TITLE
The :assets group no longer needed. Assume CSS/JS assets by default.

### DIFF
--- a/bin/_inserts
+++ b/bin/_inserts
@@ -19,15 +19,6 @@ sed --in-place \
   's/RenameMe/{% include "_cctmp\/class_name.txt" %}/' \
   config/application.rb
 
-# Rails applications have long relied on JavaScript gems
-# to build assets and lazily keep those un-used gems on
-# our hosts even though we precompile. In order to avoid
-# a ExecJS runtime error on Lambda which has no hint of
-# JavaScript runtimes present for Ruby, we create an
-# `:assets` Bundler group like the days of old.
-#
-insert_file_over_pattern 'config/application.rb' 'Bundler.require'
-
 # Create a simple welcome to Lamby/Rails index page. To do
 # this we need a simple starter route, view layout and template.
 # One important part of this is exercising the JS/CSS assets.

--- a/bin/_lambify
+++ b/bin/_lambify
@@ -56,7 +56,6 @@ cp ./lambify/docker-compose.yml "${PROJECT_FOLDER}/docker-compose.yml"
 #
 # - Remove `ruby` declaration. Helps minor udpates
 # - Add Lamby gem along with Dotenv.
-# - Creates an `:assets` group. Avoids loading these in prod.
 # - Add lograge gem to reduce CloudWatch noise/costs.
 #
 cp ./lambify/Gemfile "$PROJECT_FOLDER/Gemfile"

--- a/inserts/app/views/layouts/application.html.erb
+++ b/inserts/app/views/layouts/application.html.erb
@@ -5,8 +5,8 @@
     <title>{% include "_cctmp/class_name.txt" %}</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%# stylesheet_link_tag 'application', media: 'all' %>
-    <%# javascript_pack_tag 'application' %>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= javascript_pack_tag 'application' %>
   </head>
   <body>
     <%= yield %>

--- a/inserts/config/application.rb
+++ b/inserts/config/application.rb
@@ -1,5 +1,0 @@
-Bundler.require(*Rails.groups.tap { |groups|
-  if Rails.env.development? || Rails.env.test?
-    groups << 'assets'
-  end
-})

--- a/lambify/Gemfile
+++ b/lambify/Gemfile
@@ -7,10 +7,7 @@ gem 'dotenv-rails', require: false
 gem 'jbuilder'
 gem 'lamby', require: false
 gem 'webpacker'
-
-group :assets do
-  gem 'sass-rails'
-end
+gem 'sass-rails'
 
 group :development do
   gem 'web-console'

--- a/lambify/bin/_build
+++ b/lambify/bin/_build
@@ -27,9 +27,7 @@ echo "== Environments & Configuration =="
 #   LAMBY_SSM_PARAMS_PATH="/{% include "_cctmp/file_name.txt" %}/${RAILS_ENV}/env"
 
 echo "== Asset Hosts & Precompiling =="
-# NODE_ENV='production' \
-#   RAILS_GROUPS=assets \
-#   ./bin/rails assets:precompile
+NODE_ENV='production' ./bin/rails assets:precompile
 
 echo "== Cleanup Unused Files & Directories =="
 rm -rf \

--- a/{{cookiecutter.project_name}}/Gemfile
+++ b/{{cookiecutter.project_name}}/Gemfile
@@ -7,10 +7,7 @@ gem 'dotenv-rails', require: false
 gem 'jbuilder'
 gem 'lamby', require: false
 gem 'webpacker'
-
-group :assets do
-  gem 'sass-rails'
-end
+gem 'sass-rails'
 
 group :development do
   gem 'web-console'

--- a/{{cookiecutter.project_name}}/app/views/layouts/application.html.erb
+++ b/{{cookiecutter.project_name}}/app/views/layouts/application.html.erb
@@ -5,8 +5,8 @@
     <title>{% include "_cctmp/class_name.txt" %}</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%# stylesheet_link_tag 'application', media: 'all' %>
-    <%# javascript_pack_tag 'application' %>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= javascript_pack_tag 'application' %>
   </head>
   <body>
     <%= yield %>

--- a/{{cookiecutter.project_name}}/bin/_build
+++ b/{{cookiecutter.project_name}}/bin/_build
@@ -27,9 +27,7 @@ echo "== Environments & Configuration =="
 #   LAMBY_SSM_PARAMS_PATH="/{% include "_cctmp/file_name.txt" %}/${RAILS_ENV}/env"
 
 echo "== Asset Hosts & Precompiling =="
-# NODE_ENV='production' \
-#   RAILS_GROUPS=assets \
-#   ./bin/rails assets:precompile
+NODE_ENV='production' ./bin/rails assets:precompile
 
 echo "== Cleanup Unused Files & Directories =="
 rm -rf \

--- a/{{cookiecutter.project_name}}/config/application.rb
+++ b/{{cookiecutter.project_name}}/config/application.rb
@@ -17,11 +17,7 @@ require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
-Bundler.require(*Rails.groups.tap { |groups|
-  if Rails.env.development? || Rails.env.test?
-    groups << 'assets'
-  end
-})
+Bundler.require(*Rails.groups)
 
 module {% include "_cctmp/class_name.txt" %}
   class Application < Rails::Application

--- a/{{cookiecutter.project_name}}/package.json
+++ b/{{cookiecutter.project_name}}/package.json
@@ -8,6 +8,6 @@
   },
   "version": "0.1.0",
   "devDependencies": {
-    "webpack-dev-server": "^3.11.1"
+    "webpack-dev-server": "^3.11.2"
   }
 }


### PR DESCRIPTION
As part of https://github.com/customink/lamby/pull/61 we want it to be super easy to get up and running with Sass, JavaScript and all the fun stuff Rails allows us to use. This makes sense for a default and if people want to use this Cookiecutter for an API then they can remove what they do not need.