### PR TITLE
Enhance Deploy with CI/CD Best Practices

### DIFF
--- a/bin/_lambify
+++ b/bin/_lambify
@@ -63,3 +63,8 @@ cp ./lambify/Gemfile "$PROJECT_FOLDER/Gemfile"
 # that describes how to package and run your Lambda.
 #
 cp ./lambify/template.yaml "$PROJECT_FOLDER/template.yaml"
+
+# Demonstrate using good CI/CD practicues. Using GitHub Actions
+# here for both a simple test and depploy workflow.
+#
+cp -r ./lambify/.github "$PROJECT_FOLDER"

--- a/inserts/.gitignore
+++ b/inserts/.gitignore
@@ -1,7 +1,6 @@
 
 # Lamby
 /.aws-sam
-/.lamby
 .env.*
 !.env.development
 !.env.test

--- a/lambify/.github/workflows/deploy.yml
+++ b/lambify/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy
+on: workflow_dispatch
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Environment
+        run: |
+          echo "UID=$(id -u)" >> $GITHUB_ENV
+          echo "GID=$(id -g)" >> $GITHUB_ENV
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./vendor/bundle
+            ./node_modules
+          key: {{ "${{ runner.os }}-deploy-${{ hashFiles('Gemfile.lock', 'yarn.lock') }}" }}
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: {{ "${{ secrets.AWS_ACCESS_KEY_ID }}" }}
+          aws-secret-access-key: {{ "${{ secrets.AWS_SECRET_ACCESS_KEY }}" }}
+          aws-region: us-east-1
+      - name: Bootstrap
+        run: |
+          ./bin/bootstrap
+      - name: Deploy
+        run: |
+          ./bin/deploy

--- a/lambify/.github/workflows/test.yml
+++ b/lambify/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Environment
+        run: |
+          echo "UID=$(id -u)" >> $GITHUB_ENV
+          echo "GID=$(id -g)" >> $GITHUB_ENV
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./vendor/bundle
+            ./node_modules
+          key: ${{ runner.os }}-test-${{ hashFiles('Gemfile.lock', 'yarn.lock') }}
+      - name: Bootstrap
+        run: |
+          ./bin/bootstrap
+      - name: Setup
+        run: |
+          ./bin/setup
+      - name: Test
+        run: |
+          ./bin/test

--- a/lambify/Dockerfile
+++ b/lambify/Dockerfile
@@ -1,5 +1,15 @@
 FROM public.ecr.aws/lambda/ruby:2.7
 ARG RAILS_ENV
 ENV RAILS_ENV=$RAILS_ENV
+
 COPY . .
+
+# == Cleanup Unused Files & Directories ==
+RUN rm -rf \
+    log \
+    node_modules \
+    test \
+    tmp \
+    vendor/bundle/ruby/2.7.0/cache
+
 CMD ["app.handler"]

--- a/lambify/bin/_bootstrap
+++ b/lambify/bin/_bootstrap
@@ -1,20 +1,6 @@
 #!/bin/sh
 set -e
 
-SAM_BUCKET_NAME_FILE=".bucket-name"
-
-if [ ! -f $SAM_BUCKET_NAME_FILE ]; then
-  echo '== Creating SAM deployment bucket =='
-  rand=$(ruby -r 'securerandom' -e 'puts(SecureRandom.hex[1,10])')
-  name="lamby-{% include "_cctmp/dash_name.txt" %}-${rand}"
-  echo -n "$name" > "$SAM_BUCKET_NAME_FILE"
-  aws s3 mb "s3://${name}"
-else
-  echo '== Using SAM deployment bucket =='
-  name=$(cat $SAM_BUCKET_NAME_FILE)
-  echo $name
-fi
-
 echo '== Creating ECR repository, if needed. =='
 echo '== Ignore any RepositoryAlreadyExistsException errors =='
 aws ecr create-repository \

--- a/lambify/bin/_build
+++ b/lambify/bin/_build
@@ -1,18 +1,12 @@
 #!/bin/sh
 set -e
 
-echo '== Simulate SAM Build Directory =='
-RESOURCE="RailsLambda"
-SAM_TEMP=$(mktemp -d -t sam.XXXXXX)
-rm -rf ./.lamby ./.aws-sam
-cp -r . "$SAM_TEMP"
-mkdir -p ./.lamby
-cp -r "$SAM_TEMP" "./.lamby/$RESOURCE"
-pushd "./.lamby/$RESOURCE"
-
-echo '== Cleaning Dev Dependencies =='
-rm -rf ./.bundle \
-       ./vendor/bundle
+if [ "$CI" != "true" ]; then
+  echo "== Cleaning dev dependencies for local deploy. Run ./bin/setup again afterward! =="
+  rm -rf ./.bundle \
+         ./vendor/bundle \
+         ./node_modules
+fi
 
 echo '== Bundle For Deployment =='
 bundle lock --add-platform x86_64-linux
@@ -29,11 +23,3 @@ echo "== Environments & Configuration =="
 
 echo "== Asset Hosts & Precompiling =="
 NODE_ENV='production' ./bin/rails assets:precompile
-
-echo "== Cleanup Unused Files & Directories =="
-rm -rf \
-  log \
-  node_modules \
-  test \
-  tmp \
-  vendor/bundle/ruby/2.7.0/cache

--- a/lambify/bin/_deploy
+++ b/lambify/bin/_deploy
@@ -1,28 +1,26 @@
 #!/bin/sh
 set -e
 
-CLOUDFORMATION_BUCKET=$(cat .bucket-name)
-
 # https://github.com/aws/aws-sam-cli/issues/2447
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 IMAGE_REPOSITORY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/{% include "_cctmp/dash_name.txt" %}"
 
+echo "== Lamby build =="
 ./bin/_build
 
+echo "== SAM build =="
 sam build \
   --parameter-overrides \
     RailsEnv="${RAILS_ENV}"
 
-echo "== SAM package..."
+echo "== SAM package =="
 sam package \
   --region "$AWS_DEFAULT_REGION" \
   --template-file ./.aws-sam/build/template.yaml \
   --output-template-file ./.aws-sam/build/packaged.yaml \
   --image-repository "$IMAGE_REPOSITORY" \
-  --s3-bucket "${CLOUDFORMATION_BUCKET}" \
-  --s3-prefix "{% include "_cctmp/dash_name.txt" %}-${RAILS_ENV}"
 
-echo "== SAM deploy..."
+echo "== SAM deploy =="
 sam deploy \
   --region "$AWS_DEFAULT_REGION" \
   --template-file ./.aws-sam/build/packaged.yaml \

--- a/lambify/bin/_setup
+++ b/lambify/bin/_setup
@@ -1,6 +1,13 @@
 #!/bin/sh
 set -e
 
+if [ "$CI" != "true" ]; then
+  echo "== Cleaning possible prod dependencies from local deploy. =="
+  rm -rf ./.bundle \
+         ./vendor/bundle \
+         ./node_modules
+fi
+
 echo '== Installing dependencies =='
 bundle lock --add-platform x86_64-linux
 bundle lock --add-platform ruby

--- a/lambify/bin/entrypoint
+++ b/lambify/bin/entrypoint
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Allow developers to use either `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` or
+# even `AWS_PROFILE` as needed. Docker compose will pass blank strings when not set
+# and will override `AWS_PROFILE`. Simple pre hack https://git.io/JsIcN
+# 
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+  unset AWS_ACCESS_KEY_ID
+  unset AWS_SECRET_ACCESS_KEY
+else
+  unset AWS_PROFILE
+fi
+
+# Execute the original script passed to docker-compose run.
+# 
+eval "$@"

--- a/lambify/docker-compose.yml
+++ b/lambify/docker-compose.yml
@@ -4,10 +4,15 @@ services:
     build:
       context: '.'
       dockerfile: Dockerfile-build
+    entrypoint: ./bin/entrypoint
     environment:
       - RAILS_ENV=${RAILS_ENV-development}
       - SAM_CLI_TELEMETRY=0
       - AWS_PROFILE=${AWS_PROFILE-default}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION-us-east-1}
+      - CI=${CI}
     volumes:
       - ${PWD}:/var/task
       - ${HOME}/.aws:/root/.aws

--- a/lambify/template.yaml
+++ b/lambify/template.yaml
@@ -23,7 +23,7 @@ Resources:
   RailsLambda:
     Type: AWS::Serverless::Function
     Metadata:
-      DockerContext: ./.lamby/RailsLambda
+      DockerContext: .
       Dockerfile: Dockerfile
       DockerTag: web
       DockerBuildArgs:

--- a/{{cookiecutter.project_name}}/.github/workflows/deploy.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy
+on: workflow_dispatch
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Environment
+        run: |
+          echo "UID=$(id -u)" >> $GITHUB_ENV
+          echo "GID=$(id -g)" >> $GITHUB_ENV
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./vendor/bundle
+            ./node_modules
+          key: {{ "${{ runner.os }}-deploy-${{ hashFiles('Gemfile.lock', 'yarn.lock') }}" }}
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: {{ "${{ secrets.AWS_ACCESS_KEY_ID }}" }}
+          aws-secret-access-key: {{ "${{ secrets.AWS_SECRET_ACCESS_KEY }}" }}
+          aws-region: us-east-1
+      - name: Bootstrap
+        run: |
+          ./bin/bootstrap
+      - name: Deploy
+        run: |
+          ./bin/deploy

--- a/{{cookiecutter.project_name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Environment
+        run: |
+          echo "UID=$(id -u)" >> $GITHUB_ENV
+          echo "GID=$(id -g)" >> $GITHUB_ENV
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./vendor/bundle
+            ./node_modules
+          key: ${{ runner.os }}-test-${{ hashFiles('Gemfile.lock', 'yarn.lock') }}
+      - name: Bootstrap
+        run: |
+          ./bin/bootstrap
+      - name: Setup
+        run: |
+          ./bin/setup
+      - name: Test
+        run: |
+          ./bin/test

--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -34,7 +34,6 @@ yarn-debug.log*
 
 # Lamby
 /.aws-sam
-/.lamby
 .env.*
 !.env.development
 !.env.test

--- a/{{cookiecutter.project_name}}/Dockerfile
+++ b/{{cookiecutter.project_name}}/Dockerfile
@@ -1,5 +1,15 @@
 FROM public.ecr.aws/lambda/ruby:2.7
 ARG RAILS_ENV
 ENV RAILS_ENV=$RAILS_ENV
+
 COPY . .
+
+# == Cleanup Unused Files & Directories ==
+RUN rm -rf \
+    log \
+    node_modules \
+    test \
+    tmp \
+    vendor/bundle/ruby/2.7.0/cache
+
 CMD ["app.handler"]

--- a/{{cookiecutter.project_name}}/bin/_bootstrap
+++ b/{{cookiecutter.project_name}}/bin/_bootstrap
@@ -1,20 +1,6 @@
 #!/bin/sh
 set -e
 
-SAM_BUCKET_NAME_FILE=".bucket-name"
-
-if [ ! -f $SAM_BUCKET_NAME_FILE ]; then
-  echo '== Creating SAM deployment bucket =='
-  rand=$(ruby -r 'securerandom' -e 'puts(SecureRandom.hex[1,10])')
-  name="lamby-{% include "_cctmp/dash_name.txt" %}-${rand}"
-  echo -n "$name" > "$SAM_BUCKET_NAME_FILE"
-  aws s3 mb "s3://${name}"
-else
-  echo '== Using SAM deployment bucket =='
-  name=$(cat $SAM_BUCKET_NAME_FILE)
-  echo $name
-fi
-
 echo '== Creating ECR repository, if needed. =='
 echo '== Ignore any RepositoryAlreadyExistsException errors =='
 aws ecr create-repository \

--- a/{{cookiecutter.project_name}}/bin/_build
+++ b/{{cookiecutter.project_name}}/bin/_build
@@ -1,18 +1,12 @@
 #!/bin/sh
 set -e
 
-echo '== Simulate SAM Build Directory =='
-RESOURCE="RailsLambda"
-SAM_TEMP=$(mktemp -d -t sam.XXXXXX)
-rm -rf ./.lamby ./.aws-sam
-cp -r . "$SAM_TEMP"
-mkdir -p ./.lamby
-cp -r "$SAM_TEMP" "./.lamby/$RESOURCE"
-pushd "./.lamby/$RESOURCE"
-
-echo '== Cleaning Dev Dependencies =='
-rm -rf ./.bundle \
-       ./vendor/bundle
+if [ "$CI" != "true" ]; then
+  echo "== Cleaning dev dependencies for local deploy. Run ./bin/setup again afterward! =="
+  rm -rf ./.bundle \
+         ./vendor/bundle \
+         ./node_modules
+fi
 
 echo '== Bundle For Deployment =='
 bundle lock --add-platform x86_64-linux
@@ -29,11 +23,3 @@ echo "== Environments & Configuration =="
 
 echo "== Asset Hosts & Precompiling =="
 NODE_ENV='production' ./bin/rails assets:precompile
-
-echo "== Cleanup Unused Files & Directories =="
-rm -rf \
-  log \
-  node_modules \
-  test \
-  tmp \
-  vendor/bundle/ruby/2.7.0/cache

--- a/{{cookiecutter.project_name}}/bin/_deploy
+++ b/{{cookiecutter.project_name}}/bin/_deploy
@@ -1,28 +1,26 @@
 #!/bin/sh
 set -e
 
-CLOUDFORMATION_BUCKET=$(cat .bucket-name)
-
 # https://github.com/aws/aws-sam-cli/issues/2447
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 IMAGE_REPOSITORY="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/{% include "_cctmp/dash_name.txt" %}"
 
+echo "== Lamby build =="
 ./bin/_build
 
+echo "== SAM build =="
 sam build \
   --parameter-overrides \
     RailsEnv="${RAILS_ENV}"
 
-echo "== SAM package..."
+echo "== SAM package =="
 sam package \
   --region "$AWS_DEFAULT_REGION" \
   --template-file ./.aws-sam/build/template.yaml \
   --output-template-file ./.aws-sam/build/packaged.yaml \
   --image-repository "$IMAGE_REPOSITORY" \
-  --s3-bucket "${CLOUDFORMATION_BUCKET}" \
-  --s3-prefix "{% include "_cctmp/dash_name.txt" %}-${RAILS_ENV}"
 
-echo "== SAM deploy..."
+echo "== SAM deploy =="
 sam deploy \
   --region "$AWS_DEFAULT_REGION" \
   --template-file ./.aws-sam/build/packaged.yaml \

--- a/{{cookiecutter.project_name}}/bin/_setup
+++ b/{{cookiecutter.project_name}}/bin/_setup
@@ -1,6 +1,13 @@
 #!/bin/sh
 set -e
 
+if [ "$CI" != "true" ]; then
+  echo "== Cleaning possible prod dependencies from local deploy. =="
+  rm -rf ./.bundle \
+         ./vendor/bundle \
+         ./node_modules
+fi
+
 echo '== Installing dependencies =='
 bundle lock --add-platform x86_64-linux
 bundle lock --add-platform ruby

--- a/{{cookiecutter.project_name}}/bin/entrypoint
+++ b/{{cookiecutter.project_name}}/bin/entrypoint
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Allow developers to use either `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` or
+# even `AWS_PROFILE` as needed. Docker compose will pass blank strings when not set
+# and will override `AWS_PROFILE`. Simple pre hack https://git.io/JsIcN
+# 
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+  unset AWS_ACCESS_KEY_ID
+  unset AWS_SECRET_ACCESS_KEY
+else
+  unset AWS_PROFILE
+fi
+
+# Execute the original script passed to docker-compose run.
+# 
+eval "$@"

--- a/{{cookiecutter.project_name}}/docker-compose.yml
+++ b/{{cookiecutter.project_name}}/docker-compose.yml
@@ -4,10 +4,15 @@ services:
     build:
       context: '.'
       dockerfile: Dockerfile-build
+    entrypoint: ./bin/entrypoint
     environment:
       - RAILS_ENV=${RAILS_ENV-development}
       - SAM_CLI_TELEMETRY=0
       - AWS_PROFILE=${AWS_PROFILE-default}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION-us-east-1}
+      - CI=${CI}
     volumes:
       - ${PWD}:/var/task
       - ${HOME}/.aws:/root/.aws

--- a/{{cookiecutter.project_name}}/template.yaml
+++ b/{{cookiecutter.project_name}}/template.yaml
@@ -23,7 +23,7 @@ Resources:
   RailsLambda:
     Type: AWS::Serverless::Function
     Metadata:
-      DockerContext: ./.lamby/RailsLambda
+      DockerContext: .
       Dockerfile: Dockerfile
       DockerTag: web
       DockerBuildArgs:


### PR DESCRIPTION
## 🤷‍♂️ Why? 

As pointed out in https://github.com/customink/lamby/issues/83 deploys can be slow... especially if you run them from your Mac. In case you were not aware, Mac filesystem performance (https://github.com/docker/roadmap/issues/7) is just horrible no matter how you cut it. This project does not want get into solutions like docker-sync. Especially when we have the ability to promote deploys from CI/CD systems like GitHub Actions. That does mean there is a Lamby development issue on Mac where native filesystem performance would need to be helped. Maybe the Lamby starter could take an opinion on that in the future. We will see.

## 👩‍💻 What? 

There are some top level concerns we need to support here. They are, listed in order:

1. Support simple on-demand (sans CI/CD) deploys from the project.
2. Easy integrate CI/CD usage with common caching methods easily fitting in.

#### 🔐 AWS_PROFILE || AWS_(ACCESS_KEY_ID|SECRET_ACCESS_KEY)

Deploys form the developer project's host machine is done leveraging standard AWS credentials and profiles. For most they only have one `default` but for many targeting others are done via the `AWS_PROFILE` environment variable. This is why we have a volume share on the `${HOME}/.aws:/root/.aws` directory. Computers doing the deploy for us leverage the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. 

To get both 1 and 2 working together there is a virtual tug of war going on. We want to be able to pass down host environment variables in a super clean way via docker compose. Yet, adding both of these will cause issues because when not present, docker compose will create these as empty strings. Meaning if the key/secret are not present, there is no way for `AWS_PROFILE` to work.

## 👷🏽 How?

Here are some high level points on how we are going to accomplish the goals of this pull request. Detailed code callouts will speak to each:

- Use a docker compose `entrypoint` to set/unset AWS environment variables as needed. This script will then call whatever bin wrapper is being requested for us. So doing a `./bin/server` essentially calls `./bin/entrypoint ./bin/_server` for us. We do this in the compose file so we do not have to apply the `--entrypoint` to all compose run bin wrapper. BTW, I am super proud of this hack. See this docker compose feature request on where I got the idea. https://github.com/docker/compose/issues/6736
- Add simple GitHub workflows for both `test` and `deploy` where deploy is a simple [workflow dispatch](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch) event. Basically click a button deploy. Both these actions leverage [actions/cache](https://github.com/actions/cache) to cache Bundler & Yarn installations. Note, we are not treading into Docker caching. We get layer caching on the ECR push automatically and numerous posts (https://dev.to/dtinth/caching-docker-builds-in-github-actions-which-approach-is-the-fastest-a-research-18ei) mention how docker pulls are already fast. If someone wants to demonstrate caching Docker with AWS SAM more I'd like to see it. 
- 

#### 📉 Benchmarks?

- ~15m - Deploy from Mac
- ~5m - Deploy from GitHub Actions
- ~3m - Deploy from GitHub Actions (with cache)

## Guides

There will be some guides changes coming very shortly to outline this in both our Getting Started & Deploy sections. Here are some things we will cover:

- How to create a basic IAM user for Lambda Deploys and setting secrets for GitHub Actions.