### PR TITLE
Fix Deploys for Mac Users

### DIFF
--- a/lambify/Dockerfile-build
+++ b/lambify/Dockerfile-build
@@ -3,6 +3,7 @@ FROM amazon/aws-sam-cli-build-image-ruby2.7
 # Lamby user to mirror host machine user:group.
 ARG HOST_UID
 ARG HOST_GID
+ENV HOME=/lamby
 RUN mkdir /lamby \
     && /usr/sbin/groupadd --gid $HOST_GID --system --force lamby \
     && /usr/sbin/useradd --uid $HOST_UID --gid $HOST_GID --non-unique --home-dir /lamby --shell /bin/bash --system lamby \

--- a/{{cookiecutter.project_name}}/Dockerfile-build
+++ b/{{cookiecutter.project_name}}/Dockerfile-build
@@ -3,6 +3,7 @@ FROM amazon/aws-sam-cli-build-image-ruby2.7
 # Lamby user to mirror host machine user:group.
 ARG HOST_UID
 ARG HOST_GID
+ENV HOME=/lamby
 RUN mkdir /lamby \
     && /usr/sbin/groupadd --gid $HOST_GID --system --force lamby \
     && /usr/sbin/useradd --uid $HOST_UID --gid $HOST_GID --non-unique --home-dir /lamby --shell /bin/bash --system lamby \


### PR DESCRIPTION
For this Lamby starter we support deploys from the host machine by leveraging AWS_PROFILE and passing that thru the dev container. Based on work done previously #11 we did some work to ensure a `lamby` user was in place for Linux which matched the hosts UID/GID. For Mac we set these to zero so that the root user could still be used. Since we share the `~/.aws` directory for the dev/build container, this caused a problem on Mac only because `$HOME` was still `/root` since the first user matching the `lamby` user set in the compose file was that user. In order to keep all these plates spinning, local dev with Mac, Linux, project deploys from both, and CD which is typically linux the simplest way to fix Mac was to be explicit about the `$HOME` directory so when the AWS CLI and AWS SAM CLI are used it works correctly.