### PR TITLE
Leverage SAM version tag on Public ECR Images

### DIFF
--- a/lambify/Dockerfile-build
+++ b/lambify/Dockerfile-build
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/sam/build-ruby2.7
+FROM public.ecr.aws/sam/build-ruby2.7:1.26
 
 # Lamby user to mirror host machine user:group.
 ARG HOST_UID
@@ -8,14 +8,6 @@ RUN mkdir /lamby \
     && /usr/sbin/groupadd --gid $HOST_GID --system --force lamby \
     && /usr/sbin/useradd --uid $HOST_UID --gid $HOST_GID --non-unique --home-dir /lamby --shell /bin/bash --system lamby \
     && chown $HOST_UID:$HOST_GID /lamby
-
-# Ensure minimum required SAM version.
-ENV SAM_CLI_VERSION=1.23.0
-RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v${SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
-         -o "aws-sam-cli-linux-x86_64.zip" && \
-    unzip -q aws-sam-cli-linux-x86_64.zip -d sam-installation && \
-    ./sam-installation/install && \
-    rm -rf ./sam-installation ./aws-sam-cli-linux-x86_64.zip
 
 # Node for JavaScript.
 RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash - && \

--- a/{{cookiecutter.project_name}}/Dockerfile-build
+++ b/{{cookiecutter.project_name}}/Dockerfile-build
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/sam/build-ruby2.7
+FROM public.ecr.aws/sam/build-ruby2.7:1.26
 
 # Lamby user to mirror host machine user:group.
 ARG HOST_UID
@@ -8,14 +8,6 @@ RUN mkdir /lamby \
     && /usr/sbin/groupadd --gid $HOST_GID --system --force lamby \
     && /usr/sbin/useradd --uid $HOST_UID --gid $HOST_GID --non-unique --home-dir /lamby --shell /bin/bash --system lamby \
     && chown $HOST_UID:$HOST_GID /lamby
-
-# Ensure minimum required SAM version.
-ENV SAM_CLI_VERSION=1.23.0
-RUN curl -L "https://github.com/aws/aws-sam-cli/releases/download/v${SAM_CLI_VERSION}/aws-sam-cli-linux-x86_64.zip" \
-         -o "aws-sam-cli-linux-x86_64.zip" && \
-    unzip -q aws-sam-cli-linux-x86_64.zip -d sam-installation && \
-    ./sam-installation/install && \
-    rm -rf ./sam-installation ./aws-sam-cli-linux-x86_64.zip
 
 # Node for JavaScript.
 RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash - && \


### PR DESCRIPTION
Similar to the work done in #14 where we switched to AWS' public ECR images for the Lamby development/test/build container. But in this change we are stopping the practice of locking down the SAM version by using the fancy linux install and instead will be using the Docker tag. So for example, this image will use any SAM v1.26.x installed by AWS on these images.

```Dockerfile
FROM public.ecr.aws/sam/build-ruby2.7:1.26
```
