### PR TITLE
Fix "Database Options" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An [AWS SAM cookiecutter](https://technology.customink.com/blog/2020/03/13/using
 - Rails v6.x on Ruby 2.7 runtime.
 - Integrated JavaScript development.
 - Compiles CSS/JS assets with LibSass & Webpacker.
-- No ActiveRecord. Read our [Database Options](https://lamby.custominktech.com/docs/database_connections) guides.
+- No ActiveRecord. Read our [Database Options](https://lamby.custominktech.com/docs/database_options) guides.
 
 **[Lamby: Simple Rails & AWS Lambda Integration using Rack.](https://lamby.custominktech.com)**
 


### PR DESCRIPTION
### Description

The "Database Options" link in README doesn't lead to the expected page.

### Changes

Change url to https://lamby.custominktech.com/docs/database_options

##### Updated Dependencies
 - None

### Ticket
 - None

### Screenshots

<!--
Please include any screenshots that communicate the visual story of the change that is being made.
-->

### Notes

<!--
Please include any notes that might be helpful for a reviewer to keep in mind while reading the changes.
-->

### Optional Tasks

<!--
Common, optional tasks are included here in case you forgot something important.
-->

- [ ] Include 🎩 Instructions
- [x] Update the readme (README.md)
- [ ] Update the API or architecture docs (e.g. docs/api.md)

##### Library-Specific

- [ ] Increment the changelog (CHANGELOG.md)
- [ ] Increment the version number (lib/version.rb)
- [ ] [Release & Tag][release] the version above in Github

[release]: https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository

##### Performance
- Are there any new queries in your change set that might require new indexes?
- Do any new queries require time-boxing to avoid table-scans when the data grows?

### What GIF Best Describes This Pull Request?

<!--
![](https://i.giphy.com/media/WNuF3KK9NaQ8w/source.gif)
-->
