### PR TITLE
Remove public/assets from .dockerignore

### DIFF
--- a/{{cookiecutter.project_name}}/.dockerignore
+++ b/{{cookiecutter.project_name}}/.dockerignore
@@ -34,4 +34,3 @@
 /node_modules/
 /app/assets/builds/*
 !/app/assets/builds/.keep
-/public/assets


### PR DESCRIPTION
Ignoring public assets breaks sites using the vanilla cookiecutter config.

This change was called for in the thread on this issue https://github.com/rails-lambda/lamby-cookiecutter/issues/43, figured I'd knock it out real quick.