### PR TITLE
Fix interpolation issue in ci.yml

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -96,5 +96,5 @@ jobs:
         if: failure()
         with:
           name: screenshots
-          path: ${{ github.workspace }}/tmp/screenshots
+          path: {{ "${{ github.workspace }}/tmp/screenshots" }}
           if-no-files-found: ignore


### PR DESCRIPTION
Attempting to run the cookie cutter runs a command that should actually be output as a string in the generated template.