### PR TITLE
Fix GH Actions path variable

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -96,5 +96,5 @@ jobs:
         if: failure()
         with:
           name: screenshots
-          path: ${{ github.workspace }}/tmp/screenshots
+          path: {{ "${{ github.workspace }}/tmp/screenshots" }}
           if-no-files-found: ignore


### PR DESCRIPTION
The command to create a new project does not work anymore. Here is the error message:
```shell
docker run \
  --rm \
  --interactive \
  --volume "${PWD}:/var/task" \
  ghcr.io/rails-lambda/lamby-cookiecutter \
  "gh:rails-lambda/lamby-cookiecutter"


project_name [my_awesome_lambda]: project_name

Unable to create file '.github/workflows/ci.yml'
Error message: 'github' is undefined
Context: {
    "cookiecutter": {
        "_output_dir": "/var/task",
        "_template": "gh:rails-lambda/lamby-cookiecutter",
        "project_name": "project_name"
    }
}
```

I think the error only comes from the CI GitHub action file. Could you merge this PR?
Thanks